### PR TITLE
Multi run with counts

### DIFF
--- a/apps/rabbitmq_statsdb_stress_test/ebin/rabbitmq_statsdb_stress_test.app
+++ b/apps/rabbitmq_statsdb_stress_test/ebin/rabbitmq_statsdb_stress_test.app
@@ -1,8 +1,9 @@
 { application, rabbitmq_statsdb_stress_test, [
     { description, "Rabbit MQ Stats DB Stress Test" },
-    { vsn, 0.1 },
+    { vsn, 0.2 },
     { modules, [
-        rabbit_mgmt_db_stressor
+        rabbit_mgmt_db_stressor,
+        rabbit_mgmt_db_stress_stats
     ] },
     { registered, [] },
     { applications, [

--- a/apps/rabbitmq_statsdb_stress_test/src/rabbit_mgmt_db_stress_stats.erl
+++ b/apps/rabbitmq_statsdb_stress_test/src/rabbit_mgmt_db_stress_stats.erl
@@ -1,0 +1,106 @@
+-module(rabbit_mgmt_db_stress_stats).
+
+-behaviour(gen_server).
+
+-export([start_link/0, stop/0, reset/0, get/1, message_queue_len/1, handle_cast_time/2]).
+
+% Export the gen_server callback functions.
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+        code_change/3, terminate/2]).
+
+
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec stop() -> ok.
+stop() ->
+    gen_server:cast(?MODULE, stop).
+
+-spec reset() -> ok.
+reset() ->
+    gen_server:call(?MODULE, reset).
+
+-spec get(non_neg_integer()) -> term().
+get(N) ->
+    ok = wait_until_ready(N),
+    gen_server:call(?MODULE, get, infinity).
+
+-spec wait_until_ready(non_neg_integer()) -> ok.
+wait_until_ready(N) ->
+    case gen_server:call(?MODULE, {stats_are_ready, N}) of
+        true -> ok;
+        false -> timer:sleep(100), wait_until_ready(N)
+    end.
+
+-spec message_queue_len(non_neg_integer()) -> ok.
+message_queue_len(Len) ->
+    gen_server:cast(?MODULE, {message_queue_len, Len}).
+
+-spec handle_cast_time(atom(), non_neg_integer()) -> ok.
+handle_cast_time(Event, Time_Elapsed) ->
+    gen_server:cast(?MODULE, {handle_cast_time, Event, Time_Elapsed}).
+
+
+% We know that we are ready to give stats results when the expected
+% number of handle_cast calls has been recorded. Because the monitored
+% Rabbit MQ also call into the stats db, we'll add a fudge factor onto
+% the expected number of casts.
+
+-record(state, {
+    msg_counts = [] :: [non_neg_integer()],
+    handle_cast_times = [] :: [{atom(), [non_neg_integer()]}],
+    handle_cast_count = 0 :: non_neg_integer()
+}).
+-define(CAST_COUNT_FUDGE, 2).
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_call(reset, _From, #state{}) ->
+    {reply, ok, #state{}};
+handle_call({stats_are_ready, N}, _From, #state{handle_cast_count = Cast_Count} = State) ->
+    Result = Cast_Count > (N + ?CAST_COUNT_FUDGE),
+    {reply, Result, State};
+handle_call(get, _From,
+        #state{msg_counts=Msg_Counts, handle_cast_times = Cast_Times} = State) ->
+    Msg_Stats = bear:get_statistics(lists:reverse(Msg_Counts)),
+    Cast_Stats = [
+        {Event, bear:get_statistics(lists:reverse(Event_Times))}
+        || {Event, Event_Times} <- Cast_Times
+    ],
+    {reply, [{msg_counts, Msg_Stats} | Cast_Stats], State};
+handle_call(_Request, _From, State) ->
+    {reply, bad_request, State}.
+
+handle_cast(stop, State) ->
+    {stop, normal, State};
+handle_cast({message_queue_len, Len}, #state{msg_counts=Msg_Counts} = State) ->
+    {noreply, State#state{msg_counts = [Len | Msg_Counts]}};
+handle_cast({handle_cast_time, Event, Micros},
+        #state{handle_cast_times = Cast_Times, handle_cast_count = Cast_Count} = State) ->
+    {noreply, State#state{
+        handle_cast_times = add_event_cast_time(Event, Micros, Cast_Times),
+        handle_cast_count = Cast_Count + 1
+    }};
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_Old, State, _Extra) ->
+    {ok, State}.
+
+-spec add_event_cast_time(atom(), non_neg_integer(), [{atom(), [non_neg_integer()]}])
+        -> [{atom(), [non_neg_integer()]}].
+add_event_cast_time(Event, Micros, Cast_Times) ->
+    case lists:keyfind(Event, 1, Cast_Times) of
+        false ->
+            lists:keystore(Event, 1, Cast_Times, {Event, [Micros]});
+        {Event, Event_Times} ->
+            lists:keyreplace(Event, 1, Cast_Times, {Event, [Micros | Event_Times]})
+    end.

--- a/apps/rabbitmq_statsdb_stress_test/src/rabbit_mgmt_db_stressor.erl
+++ b/apps/rabbitmq_statsdb_stress_test/src/rabbit_mgmt_db_stressor.erl
@@ -21,26 +21,50 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -compile([export_all]).
--export([run/1, message_queue_len/3]).
+-export([run/1, clear_tracer/1, message_queue_len/2]).
 
--record(agg, {
-    msg_counts = [],
-    handle_cast_times = []
+
+-define(DEFAULT_COUNTS, [10, 100, 1000]).
+
+-record(generate_event_counts, {
+  connections = ?DEFAULT_COUNTS :: [non_neg_integer()],
+  channels_per_connection = ?DEFAULT_COUNTS :: [non_neg_integer()],
+  stats_per_connection = ?DEFAULT_COUNTS :: [non_neg_integer()],
+  stats_per_channel = ?DEFAULT_COUNTS :: [non_neg_integer()],
+  queues_per_channel = ?DEFAULT_COUNTS :: [non_neg_integer()],
+  stats_per_queue = ?DEFAULT_COUNTS :: [non_neg_integer()]
 }).
 
+% Clear a potentially stuck tracer as set up below in start_handle_cast_tracer/3
+-spec clear_tracer([string()]) -> ok.
+clear_tracer([Nodename]) when is_list(Nodename) ->
+    Node = nodename(Nodename),
+    case net_adm:ping(Node) of
+        pong ->
+            1 = rpc:call(Node, erlang, trace,
+                [global:whereis_name(stats_receiver()), false, [call, timestamp]]);
+        pang ->
+            io:format(standard_error, "Could not connect to ~p.~n", [Node]),
+            halt(1)
+    end,
+    ok.
 
 -spec run([string()]) -> ok.
-run([Nodename, CSV]) when is_list(Nodename) ->
-    Node = case lists:member($@, Nodename) of
+run([Nodename, CSV]) when is_list(Nodename), is_list(CSV) ->
+    Node = nodename(Nodename),
+    case net_adm:ping(Node) of
+        pong -> io:format("Connected to ~p.~n", [Node]), run_on_node(Node, CSV);
+        pang -> io:format(standard_error, "Could not connect to ~p.~n", [Node]), halt(1)
+    end.
+
+-spec nodename(string()) -> atom().
+nodename(Nodename) ->
+    case lists:member($@, Nodename) of
         true ->
             list_to_atom(Nodename);
         false ->
             {ok, Hostname} = inet:gethostname(),
             list_to_atom(Nodename ++ "@" ++ Hostname)
-    end,
-    case net_adm:ping(Node) of
-        pong -> io:format("Connected to ~p.~n", [Node]), run_on_node(Node, CSV);
-        pang -> io:format(standard_error, "Could not connect to ~p.~n", [Node]), halt(1)
     end.
 
 -spec run_on_node(atom(), string()) -> ok.
@@ -48,32 +72,26 @@ run_on_node(Node, CSV) ->
     Stats_Receiver = stats_receiver(),
     Stats_Pid = global:whereis_name(Stats_Receiver),
     io:format("Stats DB is at ~p (~p).~n", [Stats_Receiver, Stats_Pid]),
-    Aggregator = spawn_link(fun () -> aggregator(#agg{}) end),
-    {ok, Msg_Q_Len} = timer:apply_interval(100, ?MODULE, message_queue_len, [Node, Stats_Pid, Aggregator]),
-    start_handle_cast_tracer(Node, Stats_Receiver, Stats_Pid, Aggregator),
-    generate_events({global, Stats_Receiver}),
+    {ok, _} = rabbit_mgmt_db_stress_stats:start_link(),
+    {ok, Msg_Q_Len} = timer:apply_interval(100, ?MODULE, message_queue_len, [Node, Stats_Pid]),
+    start_handle_cast_tracer(Node, Stats_Receiver, Stats_Pid),
+    generate_events({global, Stats_Receiver}, #generate_event_counts{}, CSV),
     stop_handle_cast_tracer(),
     {ok, cancel} = timer:cancel(Msg_Q_Len),
-    io:format("Rolling up statistics, this might take a moment ....~n"),
-    Aggregator ! {get, self()},
-    Aggregator ! stop,
-    receive
-        Stats ->
-            write_to_csv(CSV, Stats),
-            io:format("Message queue length (100ms samples):~n    ~p~n", [Stats])
-    end.
+    ok = rabbit_mgmt_db_stress_stats:stop().
 
 
--spec message_queue_len(atom(), pid(), pid()) -> {message_queue_len, non_neg_integer()}.
-message_queue_len(Node, Stats_Pid, Aggregator) ->
-    {message_queue_len, _Len} = Aggregator ! rpc:call(Node, erlang, process_info, [Stats_Pid, message_queue_len]).
+-spec message_queue_len(atom(), pid()) -> ok.
+message_queue_len(Node, Stats_Pid) ->
+    {message_queue_len, Len} = rpc:call(Node, erlang, process_info, [Stats_Pid, message_queue_len]),
+    rabbit_mgmt_db_stress_stats:message_queue_len(Len).
 
--type tracer_state() :: {atom(), atom(), atom(), erlang:timestamp(), pid()}.
--spec start_handle_cast_tracer(atom(), atom(), pid(), pid()) -> ok.
-start_handle_cast_tracer(Node, Stats_Receiver, Stats_Pid, Aggregator) ->
+-type tracer_state() :: {atom(), atom(), atom(), erlang:timestamp()}.
+-spec start_handle_cast_tracer(atom(), atom(), pid()) -> ok.
+start_handle_cast_tracer(Node, Stats_Receiver, Stats_Pid) ->
     TS = undefined,
     Event = undefined,
-    Tracer_State = {Stats_Receiver, handle_cast, Event, TS, Aggregator},
+    Tracer_State = {Stats_Receiver, handle_cast, Event, TS},
     {ok, _Tracer} = dbg:tracer(process, {fun handle_cast_tracer/2, Tracer_State}),
     {ok, Node} = dbg:n(Node),
     ok = dbg:cn(node()),
@@ -89,67 +107,65 @@ stop_handle_cast_tracer() ->
 handle_cast_tracer({trace_ts, _Pid, call,
             {Stats_Receiver, handle_cast, [{event, #event{type = Event}}, _State]},
             TS},
-        {Stats_Receiver, handle_cast, undefined, undefined, Aggregator}) ->
-    {Stats_Receiver, handle_cast, Event, TS, Aggregator};
+        {Stats_Receiver, handle_cast, undefined, undefined}) ->
+    {Stats_Receiver, handle_cast, Event, TS};
 handle_cast_tracer({trace_ts, _Pid, return_from,
             {Stats_Receiver, handle_cast, 2},
             _Result,
             TS2},
-        {Stats_Receiver, handle_cast, Event, TS1, Aggregator}) ->
+        {Stats_Receiver, handle_cast, Event, TS1}) ->
     Time_Elapsed = now_to_micros(TS2) - now_to_micros(TS1),
-    Aggregator ! {handle_cast_time, Event, Time_Elapsed},
-    {Stats_Receiver, handle_cast, undefined, undefined, Aggregator};
+    rabbit_mgmt_db_stress_stats:handle_cast_time(Event, Time_Elapsed),
+    {Stats_Receiver, handle_cast, undefined, undefined};
 handle_cast_tracer(Msg, State) ->
     io:format(standard_error, "Unexpected handle_call tracer message:~n    ~p~n", [Msg]),
     State.
 
--spec aggregator(#agg{}) -> ok.
-aggregator(#agg{msg_counts=Msg_Counts, handle_cast_times = Cast_Times} = Agg) ->
-    receive
-        stop ->
-            ok;
-        {message_queue_len, Len} ->
-            aggregator(Agg#agg{msg_counts = [Len | Msg_Counts]});
-        {handle_cast_time, Event, Micros} ->
-            New_Cast_Times = add_event_cast_time(Event, Micros, Cast_Times),
-            aggregator(Agg#agg{handle_cast_times = New_Cast_Times});
-        {get, From} ->
-            Msg_Stats = bear:get_statistics(lists:reverse(Msg_Counts)),
-            Cast_Stats = [
-                {Event, bear:get_statistics(lists:reverse(Event_Times))}
-                || {Event, Event_Times} <- Cast_Times
-            ],
-            From ! [{msg_counts, Msg_Stats} | Cast_Stats],
-            aggregator(Agg);
-        _Info ->
-            aggregator(Agg)
-    end.
 
--spec add_event_cast_time(atom(), non_neg_integer(), [{atom(), [non_neg_integer()]}]) -> [{atom(), [non_neg_integer()]}].
-add_event_cast_time(Event, Micros, Cast_Times) ->
-    case lists:keyfind(Event, 1, Cast_Times) of
-        false ->
-            lists:keystore(Event, 1, Cast_Times, {Event, [Micros]});
-        {Event, Event_Times} ->
-            lists:keyreplace(Event, 1, Cast_Times, {Event, [Micros | Event_Times]})
-    end.
-
-
--spec generate_events({global, atom()}) -> ok.
-generate_events(Stats_DB) ->
-    Conns = [ pid_and_name(<<"Conn">>, I) || I <- lists:seq(1, 1000) ],
-    Chans = [ pid_and_name(Conn, I)  || {_, Conn} <- Conns, I <- lists:seq(1, 1000) ],
-    io:format("Generating ~p connection_created events.~n", [length(Conns)]),
-    _Conn_Createds = [ gen_server:cast(Stats_DB, {event, connection_created(Pid, Name)}) || {Pid, Name} <- Conns ],
-    io:format("Generating ~p channel_created events.~n", [length(Chans)]),
-    _Chan_Createds = [ gen_server:cast(Stats_DB, {event, channel_created(Pid, Name)}) || {Pid, Name} <- Chans ],
-    io:format("Generating ~p connection_stats events.~n", [100 * length(Conns)]),
-    _Conn_Stats = [ gen_server:cast(Stats_DB, {event, connection_stats(Pid, random:uniform(50))}) || _ <- lists:seq(1, 100), {Pid, _} <- Conns ],
-    io:format("Generating ~p channel_closed events.~n", [length(Chans)]),
-    _Chan_Closeds = [ gen_server:cast(Stats_DB, {event, channel_closed(Pid)}) || {Pid, _} <- Chans ],
-    io:format("Generating ~p connection_closed events.~n", [length(Conns)]),
-    _Conn_Closeds = [ gen_server:cast(Stats_DB, {event, connection_closed(Pid)}) || {Pid, _} <- Conns ],
+-spec generate_events({global, atom()}, #generate_event_counts{}, string()) -> ok.
+generate_events(Stats_DB, #generate_event_counts{} = Counts, CSV) ->
+    [ generate_events(Stats_DB, N_Conns, N_Chans, N_Conn_Stats, CSV)
+    || N_Conns <- Counts#generate_event_counts.connections,
+        N_Chans <- Counts#generate_event_counts.channels_per_connection,
+        N_Conn_Stats <- Counts#generate_event_counts.stats_per_connection
+    ],
     ok.
+
+-spec generate_events({global, atom()}, non_neg_integer(), non_neg_integer(), non_neg_integer(), string()) -> ok.
+generate_events(Stats_DB, N_Conns, N_Chans, N_Conn_Stats, CSV) ->
+    ok = rabbit_mgmt_db_stress_stats:reset(),
+    Conns = [ pid_and_name(<<"Conn">>, I) || I <- lists:seq(1, N_Conns) ],
+    Chans = [ pid_and_name(Conn, I)  || {_, Conn} <- Conns, I <- lists:seq(1, N_Chans) ],
+    io:format("Generating ~p connection_created events.~n", [N_Conns]),
+    [ gen_server:cast(Stats_DB, connection_created(Pid, Name))
+    || {Pid, Name} <- Conns
+    ],
+    io:format("Generating ~p channel_created events.~n", [N_Conns * N_Chans]),
+    [ gen_server:cast(Stats_DB, channel_created(Pid, Name))
+    || {Pid, Name} <- Chans
+    ],
+    io:format("Generating ~p connection_stats events.~n", [N_Conn_Stats * N_Conns]),
+    [ gen_server:cast(Stats_DB, connection_stats(Pid, random:uniform(50)))
+    || _ <- lists:seq(1, N_Conn_Stats), {Pid, _} <- Conns
+    ],
+    io:format("Generating ~p channel_closed events.~n", [N_Conns * N_Chans]),
+    [ gen_server:cast(Stats_DB, channel_closed(Pid))
+    || {Pid, _} <- Chans
+    ],
+    io:format("Generating ~p connection_closed events.~n", [N_Conns]),
+    [ gen_server:cast(Stats_DB, connection_closed(Pid))
+    || {Pid, _} <- Conns
+    ],
+    N_Total_Casts =
+        N_Conns +
+        N_Conns * N_Chans +
+        N_Conns * N_Conn_Stats +
+        N_Conns * N_Chans +
+        N_Conns,
+    io:format("Waiting to receive stats from ~p events.~n", [N_Total_Casts]),
+    Stats = rabbit_mgmt_db_stress_stats:get(N_Total_Casts),
+    write_to_csv(CSV, Stats),
+    io:format("~p~n", [Stats]).
 
 
 % Switch easily between old and new versions of the stats db.
@@ -186,22 +202,23 @@ now_to_micros({Mega, Sec, Micro}) ->
 
 % some code adapted from the test suite
 
--spec connection_created(pid(), binary()) -> #event{}.
+-spec connection_created(pid(), binary()) -> {event, #event{}}.
 connection_created(Pid, Name) when is_pid(Pid), is_binary(Name) ->
     event(connection_created, [{pid, Pid}, {name, Name}]).
 
--spec connection_stats(pid(), non_neg_integer()) -> #event{}.
+-spec connection_stats(pid(), non_neg_integer()) -> {event, #event{}}.
 connection_stats(Pid, Oct)  when is_pid(Pid), is_integer(Oct), Oct >= 0->
     event(connection_stats, [{pid, Pid}, {recv_oct, Oct}]).
 
--spec connection_closed(pid()) -> #event{}.
+-spec connection_closed(pid()) -> {event, #event{}}.
 connection_closed(Pid) when is_pid(Pid) ->
     event(connection_closed, [{pid, Pid}]).
 
--spec channel_created(pid(), binary()) -> #event{}.
+-spec channel_created(pid(), binary()) -> {event, #event{}}.
 channel_created(Pid, Name) when is_pid(Pid), is_binary(Name) ->
     event(channel_created, [{pid, Pid}, {name, Name}]).
 
+-spec channel_stats(pid(), list(), list(), list()) -> {event, #event{}}.
 channel_stats(Pid, XStats, QXStats, QStats) ->
     XStats1 = [ {exchange(XName), [{publish, N}]} || {XName, N} <- XStats ],
     QXStats1 = [ {{queue(QName), exchange(XName)}, [{publish, N}]} || {QName, XName, N} <- QXStats ],
@@ -213,31 +230,31 @@ channel_stats(Pid, XStats, QXStats, QStats) ->
         {channel_queue_stats, QStats1}
     ]).
 
--spec channel_closed(pid()) -> #event{}.
+-spec channel_closed(pid()) -> {event, #event{}}.
 channel_closed(Pid) when is_pid(Pid) ->
     event(channel_closed, [{pid, Pid}]).
 
--spec queue_created(binary()) -> #event{}.
+-spec queue_created(binary()) -> {event, #event{}}.
 queue_created(Name) when is_binary(Name) ->
     event(queue_created, [{name, queue(Name)}]).
 
--spec queue_stats(binary(), non_neg_integer()) -> #event{}.
+-spec queue_stats(binary(), non_neg_integer()) -> {event, #event{}}.
 queue_stats(Name, Msgs) when is_binary(Name), is_integer(Msgs), Msgs >= 0 ->
     event(queue_stats, [{name, queue(Name)}, {messages, Msgs}]).
 
--spec queue_deleted(binary()) -> #event{}.
+-spec queue_deleted(binary()) -> {event, #event{}}.
 queue_deleted(Name) when is_binary(Name) ->
     event(queue_deleted, [{name, queue(Name)}]).
 
 
--spec event(atom(), list()) -> #event{}.
+-spec event(atom(), list()) -> {event, #event{}}.
 event(Type, Props) ->
-    #event{
+    {event, #event{
         type = Type,
         props = Props,
         reference = none,
         timestamp = timestamp()
-    }.
+    }}.
 
 -spec queue(binary()) -> #resource{}.
 queue(Name) when is_binary(Name)->
@@ -274,7 +291,7 @@ create_header({_, Values}) ->
     Filtered = lists:sort(filter_metrics(Values)),
     format_line(metric, [K || {K, _} <- Filtered]).
 
--spec format_line(atom, [{atom(), number()}]) -> string().
+-spec format_line(atom(), [{atom(), number()}]) -> string().
 format_line(Tag, Filtered) ->
     io_lib:format("~p~s~n", [Tag, lists:flatten([io_lib:format(",~p",[Value])
                                                  || Value <- Filtered])]).

--- a/clear_tracer.sh
+++ b/clear_tracer.sh
@@ -1,0 +1,8 @@
+RABBIT=$1
+
+erl -pa apps/*/ebin deps/*/ebin \
+	-noinput \
+	-sname clear_tracer \
+	-run rabbit_mgmt_db_stressor clear_tracer $RABBIT \
+	-run init stop
+


### PR DESCRIPTION
Move the Aggregator process into it's own gen_server, so that gathered stats can be fetched and cleared.
Add the ability to specify how many events of various types are to be generated.
