### PR TITLE
Add query calls

### DIFF
--- a/apps/rabbitmq_statsdb_stress_test/src/rabbit_mgmt_db_stressor.erl
+++ b/apps/rabbitmq_statsdb_stress_test/src/rabbit_mgmt_db_stressor.erl
@@ -413,10 +413,6 @@ timestamp() ->
 now_to_micros({Mega, Sec, Micro}) ->
     1000000*1000000*Mega + 1000000*Sec + Micro.
 
--spec sample_filter(non_neg_integer()) -> boolean().
-sample_filter(N) ->
-    random:uniform(N) < 100.
-
 
 -spec vhost_created(binary()) -> {event, #event{}}.
 vhost_created(Name) when is_binary(Name) ->


### PR DESCRIPTION
Add query calls into the stress test. A process is started that will call into the `rabbit_mgmt_db` query interface. Currently these functions may get called: `get_overview/1`, `get_all_connections/1`, `get_all_channels/1`, `get_all_consumers/0`, `augment_vhosts/2`, `get_connection/2`, and `get_channel/2`.

For `get_connection` and `get_channel`, a subset of available connections / channels is used for query calls. For the `get_all_` functions, we need to be careful to turn them off if too many objects are available, otherwise these calls swamp the test. Thus they are only called with much less frequency (1/4).

The times of the calls are sent to the aggregator and appear at the end of the statistics list.

Also add queue_created and queue_deleted events. Apologies for the inconvenience.
